### PR TITLE
Call dacorateAll() when iframe is already loaded.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,10 @@
 async function init() {
     if (isCafe()) {
-        getIframe().addEventListener('load', () => decorateAll());
+        if (getIframeDocument().readyState === "complete") {
+            await decorateAll();
+        } else {
+            getIframe().addEventListener('load', () => decorateAll());
+        }
     } else if (isBlog()) {
         await decorateAll();
     } else {


### PR DESCRIPTION
네이버 카페에서 iframe 로딩이 init() 실행보다 빠를 때 화질 적용이 안 되는 문제에 대한 수정 사항입니다.