### PR TITLE
한글 입력 모드에서도 전체화면 및 음소거 단축키가 동작하도록 수정

### DIFF
--- a/js/decorator/full-screen-shortcut-decorator.js
+++ b/js/decorator/full-screen-shortcut-decorator.js
@@ -3,7 +3,7 @@ class FullScreenShortcutDecorator extends Decorator {
     decorate(prismPlayer) {
         const playerKeyDownListener = (event) => {
             if (!event.isTrusted) return;
-            if (event.key !== 'f' && event.key !== 'F') return;
+            if (event.code !== 'KeyF') return;
             prismPlayer.query('fullScreenButton').click();
         };
         prismPlayer.element.addEventListener('keydown', playerKeyDownListener);

--- a/js/decorator/mute-shortcut-decorator.js
+++ b/js/decorator/mute-shortcut-decorator.js
@@ -3,7 +3,7 @@ class MuteShortcutDecorator extends Decorator {
     decorate(prismPlayer) {
         const playerKeyDownListener = (event) => {
             if (!event.isTrusted) return;
-            if (event.key !== 'm' && event.key !== 'M') return;
+            if (event.code !== 'KeyM') return;
             prismPlayer.query('volumeButton').click();
         };
         prismPlayer.element.addEventListener('keydown', playerKeyDownListener);


### PR DESCRIPTION
먼저 좋은 확장 프로그램 감사드립니다. :)

사용하다보니 전체화면 또는 음소거 단축키를 macOS 한글 입력 모드에서 사용할 수 없고 반드시 영문 입력으로 변경해야 하는 불편함이 있어, 키보드 레이아웃(US 레이아웃, KR 레이아웃 등)에 관계 없이 전체화면 키와 뮤트 단축키가 동작하도록 수정해보았습니다.

`KeyboardEvent.key` 값이 아닌 `KeyboardEvent.code` 값을 사용해서 키보드 레이아웃에 관계 없이 각 단축키가 동작하도록 했습니다. MDN 문서에 따르면 `KeyboardEvent.code` 값은 Chrome 48 (2016-01-20 배포) 버전부터 지원하기 때문에 호환성 문제는 없을 것으로 생각합니다.

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code

한 번 살펴봐주시고 괜찮으시다면 병합 및 업데이트 부탁드겠습니다! 킹애~

